### PR TITLE
Readonly fix

### DIFF
--- a/KW.js
+++ b/KW.js
@@ -144,8 +144,8 @@
       });
       var widget = $node.data('kendoDatePicker');
       widget.wrapper.css({ width: this.props.width });
-      widget.readonly(this.props.readonly);
-      widget.enable(this.props.enabled);
+      if (this.props.readonly) { widget.readonly(true); }
+      if (!this.props.enabled) { widget.enable(false); }
       widget.bind('change', this._onChange);
     },
 
@@ -236,8 +236,8 @@
       });
       var widget = $node.data('kendoTimePicker');
       widget.wrapper.css({ width: this.props.width });
-      widget.readonly(this.props.readonly);
-      widget.enable(this.props.enabled);
+      if (this.props.readonly) { widget.readonly(true); }
+      if (!this.props.enabled) { widget.enable(false); }
       widget.bind('change', this._onChange);
     },
 
@@ -328,8 +328,8 @@
       });
       var widget = $node.data('kendoDateTimePicker');
       widget.wrapper.css({ width: this.props.width });
-      widget.enable(this.props.enabled);
-      widget.readonly(this.props.readonly);
+      if (!this.props.enabled) { widget.enable(false); }
+      if (this.props.readonly) { widget.readonly(true); }
       widget.bind('change', this._onChange);
     },
 
@@ -419,8 +419,8 @@
       // set initial enabled and readonly settings
       var widget = $node.data("kendoMaskedTextBox");
       widget.wrapper.css({ width: this.props.width });
-      widget.readonly(this.props.readonly);
-      widget.enable(this.props.enabled);
+      if (this.props.readonly) { widget.readonly(true); }
+      if (!this.props.enabled) { widget.enable(false); }
 
       // bind to widget events
       widget.bind('change', this._onChange);
@@ -525,8 +525,8 @@
       // set initial enabled and readonly settings
       var widget = $node.data("kendoNumericTextBox");
       widget.wrapper.css({ width: this.props.width });
-      widget.readonly(this.props.readonly);
-      widget.enable(this.props.enabled);
+      if (this.props.readonly) { widget.readonly(true); }
+      if (!this.props.enabled) { widget.enable(false); }
 
       // bind to widget events
       widget.bind('change', this._onChange);
@@ -627,8 +627,8 @@
       });
       var widget = $node.data('kendoDropDownList');
       widget.wrapper.css({ width: this.props.width });
-      widget.readonly(this.props.readonly);
-      widget.enable(this.props.enabled);
+      if (this.props.readonly) { widget.readonly(true); }
+      if (!this.props.enabled) { widget.enable(false); }
       widget.bind('change', this._onChange);
     },
 
@@ -744,8 +744,8 @@
       });
       var widget = $node.data('kendoComboBox');
       widget.wrapper.css({ width: this.props.width });
-      widget.readonly(this.props.readonly);
-      widget.enable(this.props.enabled);
+      if (this.props.readonly) { widget.readonly(true); }
+      if (!this.props.enabled) { widget.enable(false); }
       widget.bind('change', this._onChange);
     },
 

--- a/README.md
+++ b/README.md
@@ -91,3 +91,7 @@ You must include all props that should not revert to the widget defaults on ever
   - `dataValueField` prop rebuilds the widget on change
   - `width` prop sets uses `widget.wrapper.css()` to set the width
   - `onChange` prop is a callback that runs on `change` event
+
+## `readonly` and `enabled`
+In Kendo, calling `widget.enable(true)` overwrites the current value of `readonly` (setting it to `false`), and calling `widget.readonly(false)` overwrites the current value of `enabled` (setting it to `true`).  Therefore, you should only use `readonly` or `enabled`, but not both.  Otherwise you might have unexpected results.
+


### PR DESCRIPTION
Fixes #2 

I made it so that `widget.readonly` and `widget.enable` are only called when needed in `componentDidMount`.  This fixes the `readonly` prop.

Otherwise the following is broken in my version of kendo (2015.2.624):

``` jsx
<KW.DatePicker readonly={true} value={...} />
```
